### PR TITLE
Fix crash when minipbrt::Loader::load(filename) could not open the file provided and crash with loop subdiv

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -294,7 +294,7 @@ namespace minipbrt {
         const ImageFilm* imagefilm = dynamic_cast<const ImageFilm*>(film);
         printf("xresolution        = %d\n", imagefilm->xresolution);
         printf("yresolution        = %d\n", imagefilm->yresolution);
-        printf("cropwindow         = [ %f, %f, %f, %f ]\n", imagefilm->cropwwindow[0], imagefilm->cropwwindow[1], imagefilm->cropwwindow[2], imagefilm->cropwwindow[3]);
+        printf("cropwindow         = [ %f, %f, %f, %f ]\n", imagefilm->cropwindow[0], imagefilm->cropwindow[1], imagefilm->cropwindow[2], imagefilm->cropwindow[3]);
         printf("scale              = %f\n", imagefilm->scale);
         printf("maxsampleluminance = %f\n", imagefilm->maxsampleluminance);
         printf("diagonal           = %f mm\n", imagefilm->diagonal);

--- a/minipbrt.cpp
+++ b/minipbrt.cpp
@@ -5905,6 +5905,7 @@ namespace minipbrt {
           delete loopsubdiv;
           return false;
         }
+        loopsubdiv->num_points /= 3;
         shape = loopsubdiv;
       }
       break;

--- a/minipbrt.cpp
+++ b/minipbrt.cpp
@@ -4672,19 +4672,18 @@ namespace minipbrt {
       return false;
     }
 
-    FILE* f = nullptr;
-    if (file_open(&f, filename, "rb") != 0) {
-      set_error("Failed to open %s", filename);
-      return false;
-    }
-
     // Create the fileData array and the input buffer. This freezes their configuration settings.
     m_fileData = new FileData[m_maxIncludeDepth + 1];
     m_fileData[0].filename = copy_string(filename);
-    m_fileData[0].f = f;
+    m_fileData[0].f = nullptr;
     m_fileData[0].atEOF = false;
     m_fileData[0].bufOffset = 0;
     m_includeDepth = 0;
+
+    if (file_open(&m_fileData[0].f, filename, "rb") != 0) {
+      set_error("Failed to open %s", filename);
+      return false;
+    }
 
     m_buf = new char[m_bufCapacity + 1];
     m_buf[m_bufCapacity] = '\0';


### PR DESCRIPTION
## Fix 1
When failing to open a file ([minipbrt.cpp:4676](https://github.com/vilya/minipbrt/blob/a6f9dadb55dae3a8a051c66863fe9b2622f8c7b3/minipbrt.cpp#L4676)), minipbrt would call `set_error()` prior to the creation `m_filedata` allocated few lines after. This would create a crash when `set_error()` is trying to access the pointer to retrieve the filename and the error offset.

## Fix 2
I encountered a crash when trying to triangulate a loop subdiv. It seems that the number of points was not divided by 3 after the call to `float_vector_param` generating a crash inside the `LoopSubdiv::triangle_mesh()` function which is trying to copy `num_points * 3` floats from `float P[num_points]` to `float trimesh->P[num_points * 3]`. I fixed the issue by dividing the number of points by 3 when creating a loop subdiv.